### PR TITLE
Refactcli - Console app - edge module deployment as part of the CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vs/
 local-*/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ dotnet run -- --payload-length=2048 --burst-length=10000 target-rate=500
 Pre-requisites:
 * a TEST device (VM or real HW) provisioned with IoT Edge 1.1/1.2
 * a linux DEV machine 
-* Azure IoT Hub, Azure Stream Analytics job, Azure Event Hubs namespace with an Event Hub
+* Azure IoT Hub, Azure Stream Analytics job (see above), Azure Event Hubs
 * optional: log analytics workspace for logging edge metrics to the cloud
 
 ## Prep the IoT Edge
@@ -48,12 +48,12 @@ du -hd1 /iotedge
 The performance tests can be done with the .NET Console app, which requires .NET 5.
 The app has two modes:
 - `deploy` for deploying Azure IoT Edge modules on the pre-provisioned edge.
-- `run` mode for running multiple iterations of the tests
+- `runtest` mode for running multiple iterations of the tests.
 
 ### Deploy the transmitter module (without metrics-collector) to the pre-provisioned Edge Device Under Test (DUT)
 Deploying the modules to your IoT Edge only needs to be done once, afterwards you can run the performance test multiple times without needing to redeploy the Edge modules.
 
-```
+```bash
 dotnet run -p ./source/IotEdgePerf.ConsoleApp -- deploy  --device-id="myedgedeviceid" --image-uri "arlotito/iotedgeperf-transmitter:0.6.0" -b 200
 ```
 
@@ -66,22 +66,20 @@ In order to deploy the required modules, and additionally add the [Metrics Colle
 - `log-a-iotresourceid`: This is the IoT Hub's Resource ID.
 - `log-a-key`: the log analytics shared key.
 
-```
+```bash
 dotnet run -p ./source/IotEdgePerf.ConsoleApp -- deploy \
  --device-id="myedgedeviceid" \
 --image-uri "arlotito/iotedgeperf-transmitter:0.6.0" \
---log-a-workspaceid "/subscriptions/[]/resourceGroups/[]/providers/Microsoft.Devices/IotHubs/[]" \
---log-a-iotresourceid "[]" \
---log-a-key "[]"
+--log-a-workspaceid "/subscriptions/xyz/resourceGroups/xyz/providers/Microsoft.Devices/IotHubs/xyz" \
+--log-a-iotresourceid "xyzguid" \
+--log-a-key "xyzkey"
                                    
 ```
-
-
 
 ### Run the Console APP from any machine 
 
 ```bash
-dotnet run -p ./source/IotEdgePerf.ConsoleApp -- \
+dotnet run -p ./source/IotEdgePerf.ConsoleApp -- runtest \
   --ehName="myEventHubName" \
   --eh-conn-string="Endpoint=sb://xyz.servicebus.windows.net/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=xxx" \
   --iot-conn-string="HostName=xxx;SharedAccessKeyName=service;SharedAccessKey=xxx" \
@@ -105,7 +103,7 @@ export IOT_HUB_NAME=__redacted__
 ```
 and then run with:
 ```bash
-dotnet run -p ./source/IotEdgePerf.ConsoleApp -- \
+dotnet run -p ./source/IotEdgePerf.ConsoleApp -- runtest \
   --device-id="myEdgeDevice" \
   --payload-length=1024 \
   --burst-length=10000 \

--- a/source/IotEdgePerf.ConsoleApp/DeploymentConfigs.cs
+++ b/source/IotEdgePerf.ConsoleApp/DeploymentConfigs.cs
@@ -114,6 +114,13 @@ namespace IotEdgePerf.ConsoleApp
                         {
                             image = transmitterUri,
                             createOptions = "{}"
+                        },
+                        env = new 
+                        {
+                            LOG_LEVEL = new
+                            {
+                                 value = "debug"
+                            }
                         }
                     },
                     IoTEdgeMetricsCollector = new
@@ -167,6 +174,13 @@ namespace IotEdgePerf.ConsoleApp
                         {
                             image = transmitterUri,
                             createOptions = "{}"
+                        },
+                        env = new 
+                        {
+                            LOG_LEVEL = new
+                            {
+                                 value = "debug"
+                            }
                         }
                     }
                 };

--- a/source/IotEdgePerf.ConsoleApp/DeploymentConfigs.cs
+++ b/source/IotEdgePerf.ConsoleApp/DeploymentConfigs.cs
@@ -1,0 +1,236 @@
+
+using System;
+using System.Collections.Generic;
+using Microsoft.Azure.Devices;
+using Microsoft.Azure.Devices.Shared;
+
+namespace IotEdgePerf.ConsoleApp
+{
+
+    internal static class EdgeConfigurations
+    {
+        public static ConfigurationContent GetBaseConfigurationContent(string transmitterAcrUri, 
+                int maxUpstreamBatchSize,
+                string logAnalyticsWorkspaceId,
+                string logAnalyticsKey,
+                string logAnalyticsIoTResourceId,
+                bool addLogAnalytics = false)
+        {
+            ConfigurationContent content = new ConfigurationContent
+            {
+                ModulesContent = new Dictionary<string, IDictionary<string, object>>
+                {
+                    ["$edgeAgent"] = new Dictionary<string, object>
+                    {
+                        ["properties.desired"] = GetEdgeAgentConfiguration(transmitterAcrUri, 
+                            maxUpstreamBatchSize, 
+                            logAnalyticsWorkspaceId, 
+                            logAnalyticsKey, 
+                            logAnalyticsIoTResourceId,
+                            addLogAnalytics)
+                    },
+                    ["$edgeHub"] = new Dictionary<string, object>
+                    {
+                        ["properties.desired"] = GetEdgeHubConfiguration()
+                    },
+                    ["source"] = new Dictionary<string, object>
+                    {
+                        ["properties.desired"] = GetTwinConfigurationTransmitter()
+                    }
+                }
+            };
+
+
+            if(addLogAnalytics)
+            {
+               
+            }
+            
+            return content;
+            
+        }
+
+        private static object GetTwinConfigurationTransmitter()
+        {
+            var desiredProperties = new
+            {
+                config = new 
+                {
+                    autoStart = false,
+                    burstLength = 1000,
+                    burstWait = 7000,
+                    burstNumber = 1,
+                    targetRate = 100,
+                    payloadLength = 1024,
+                    waitBeforeStart = 0,
+                    batchSize = 1,
+                    logMsg = false,
+                    logBurst = true,
+                    logHist = false,
+                    rateCalcPeriod = 5000
+                }
+            };
+
+            return desiredProperties;
+        }
+
+        private static object GetEdgeHubConfiguration()
+        {
+            var desiredProperties = new
+            {
+                schemaVersion = "1.0",
+                routes = new Dictionary<string, string>
+                {
+                    ["route1"] = "FROM /messages/* INTO $upstream",
+                },
+                storeAndForwardConfiguration = new
+                {
+                    timeToLiveSecs = 7200
+                }
+            };
+            return desiredProperties;
+        }
+
+        private static object GetEdgeAgentConfiguration(
+            string transmitterUri, 
+            int maxUpstreamBatchSize,
+            string logAnalyticsWorkspaceId,
+            string logAnalyticsKey,
+            string logAnalyticsIoTResourceId,
+            bool addLogAnalytics = false)
+        {
+            object modules;
+            if(addLogAnalytics)
+            {
+                modules = new
+                {
+                    source = new
+                    {
+                        version = "1.0",
+                        type = "docker",
+                        status = "running",
+                        restartPolicy = "on-failure",
+                        settings = new
+                        {
+                            image = transmitterUri,
+                            createOptions = "{}"
+                        }
+                    },
+                    IoTEdgeMetricsCollector = new
+                    {
+                        version = "1.0",
+                        type = "docker",
+                        status = "running",
+                        restartPolicy = "on-failure",
+                        settings = new
+                        {
+                            image = "mcr.microsoft.com/azureiotedge-metrics-collector:1.0",
+                            createOptions = "{}"
+                        },
+                        env = new 
+                        {
+                            ResourceId = new
+                            {
+                                 value = logAnalyticsIoTResourceId
+                            },
+                            UploadTarget = new
+                            {
+                                 value = "AzureMonitor"
+                            },
+                            LogAnalyticsWorkspaceId = new
+                            {
+                                 value = logAnalyticsWorkspaceId
+                            },
+                            LogAnalyticsSharedKey = new
+                            {
+                                 value = logAnalyticsKey
+                            },
+                            MetricsEndpointsCSV = new
+                            {
+                                 value = "http://edgeAgent:9600/metrics, http://edgeHub:9600/metrics"
+                            },
+                        }
+                    }
+                };
+            }
+            else
+            {
+                modules = new
+                {
+                    transmitter = new
+                    {
+                        version = "1.0",
+                        type = "docker",
+                        status = "running",
+                        restartPolicy = "on-failure",
+                        settings = new
+                        {
+                            image = transmitterUri,
+                            createOptions = "{}"
+                        }
+                    }
+                };
+            }
+
+            var desiredProperties = new
+            {
+                schemaVersion = "1.0",
+                runtime = new
+                {
+                    type = "docker",
+                    settings = new
+                    {
+                        loggingOptions = string.Empty
+                    }
+                },
+                systemModules = new
+                {
+                    edgeAgent = new
+                    {
+                        type = "docker",
+                        settings = new
+                        {
+                            image = "mcr.microsoft.com/azureiotedge-agent:1.2",
+                            createOptions = "{}"
+                        }
+                    },
+                    edgeHub = new
+                    {
+                        type = "docker",
+                        status = "running",
+                        restartPolicy = "always",
+                        settings = new
+                        {
+                            image = "mcr.microsoft.com/azureiotedge-hub:1.2",
+                            createOptions = "{\"HostConfig\":{\"Binds\":[\"/iotedge:/tmp/edgeHub\"]}}"
+                        },
+                        env = new 
+                        {
+                            RuntimeLogLevel = new
+                            {
+                                 value = "info"
+                            },
+                            MessageCleanupIntervalSecs =  new
+                            {
+                                 value = "7200"
+                            },
+                            MaxUpstreamBatchSize = new
+                            {
+                                value = maxUpstreamBatchSize
+                            },
+                            storageFolder = new
+                            {
+                                value = "/iotedge"
+                            }
+                        }
+
+                    }
+                },
+                modules = modules
+            };
+            return desiredProperties;
+        }
+
+    }
+}
+

--- a/source/IotEdgePerf.ConsoleApp/Parameters.cs
+++ b/source/IotEdgePerf.ConsoleApp/Parameters.cs
@@ -26,7 +26,7 @@ namespace IotEdgePerf.ConsoleApp
 
     }
 
-    [Verb("run")]
+    [Verb("runtest")]
     /// <summary>
     /// Parameters for the application in Run / execute mode
     /// </summary>

--- a/source/IotEdgePerf.ConsoleApp/Parameters.cs
+++ b/source/IotEdgePerf.ConsoleApp/Parameters.cs
@@ -1,16 +1,36 @@
 ﻿// Copyright (c) Microsoft. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System;
 using CommandLine;
-using IotEdgePerf.Shared;
 
 namespace IotEdgePerf.ConsoleApp
 {
+
+    internal abstract class BaseOptions
+    {
+         [Option(
+            "iot-conn-string",
+            Required = false,
+            Default = "",
+            HelpText = "The connection string to the iot hub.\nIf you prefer, you can use the env var IOT_CONN_STRING instead.")]
+        public string IotHubConnectionString { get; set; }
+
+         [Option(
+            "device-id",
+            Required = false,
+            Default = "",
+            HelpText = "The device id. \nIf you prefer, you can use the env var DEVICE_ID instead.")]
+        public string DeviceId { get; set; }
+
+
+
+    }
+
+    [Verb("run")]
     /// <summary>
-    /// Parameters for the application
+    /// Parameters for the application in Run / execute mode
     /// </summary>
-    internal class Parameters
+    internal class RunOptions: BaseOptions
     {
         [Option(
             'n',
@@ -27,20 +47,7 @@ namespace IotEdgePerf.ConsoleApp
             HelpText = "The connection string to the event hub-compatible endpoint.\nIf you prefer, you can use the env var EH_CONN_STRING instead. Use the Azure portal to get this parameter.")]
         public string EventHubConnectionString { get; set; }
 
-        [Option(
-            "iot-conn-string",
-            Required = false,
-            Default = "",
-            HelpText = "The connection string to the iot hub.\nIf you prefer, you can use the env var IOT_CONN_STRING instead.")]
-        public string IotHubConnectionString { get; set; }
-
-        [Option(
-            "device-id",
-            Required = false,
-            Default = "",
-            HelpText = "The device id. \nIf you prefer, you can use the env var DEVICE_ID instead.")]
-        public string DeviceId { get; set; }
-
+       
         [Option(
             't',
             "timeout",
@@ -123,81 +130,43 @@ namespace IotEdgePerf.ConsoleApp
         public string TestLabel { get; set; }
     }
 
-    partial class Program
+    [Verb("deploy")]
+    internal class DeployOptions: BaseOptions
     {
-        private static void GetConfig(string[] args)
-        {
-            Parameters _parameters = new Parameters();
+        [Option(
+            "image-uri",
+            Required = true,
+            HelpText = "Container Image URI and tag, for example 'arlotito/iotedgeperf-transmitter:0.5.0'")]
+        public string ImageUri { get; set; }
 
-            // Parse application parameters
-            ParserResult<Parameters> result = Parser.Default.ParseArguments<Parameters>(args)
-                .WithParsed(parsedParams =>
-                {
-                    _parameters = parsedParams;
-                })
-                .WithNotParsed(errors =>
-                {
-                    Environment.Exit(1);
-                });
+        [Option(
+            'b', 
+            "batch-max-size",
+            Required = false,
+            Default = 200,
+            HelpText = "(optional) this value will be assigned to edgeHub's MaxUpstreamBatchSize env var.")]
+        public int MaxUpstreamBatchSize { get; set; }
 
-            _eventHubName = Environment.GetEnvironmentVariable("EH_NAME");
-            if (!string.IsNullOrEmpty(_parameters.EventHubName))
-            {
-                _eventHubName = _parameters.EventHubName;
-            }
+        [Option(
+            "log-a-workspaceid",
+            Required = false,
+            HelpText = "(optional) The Log Analytics Workspace ID")]
+        public string LogAnalyticsWorkspaceId { get; set; }
 
-            _eventHubConnectionString = Environment.GetEnvironmentVariable("EH_CONN_STRING");
-            if (!string.IsNullOrEmpty(_parameters.EventHubConnectionString))
-            {
-                _eventHubConnectionString = _parameters.EventHubConnectionString;
-            }
+        [Option(
+            "log-a-iotresourceid",
+            Required = false,
+            HelpText = "(optional but required when adding Log Analytics) The IoT Hub resource ID")]
+        public string LogAnalyticsIoTResourceId { get; set; }
 
-            _iotHubConnectionString = Environment.GetEnvironmentVariable("IOT_CONN_STRING");
-            if (!string.IsNullOrEmpty(_parameters.IotHubConnectionString))
-            {
-                _iotHubConnectionString = _parameters.IotHubConnectionString;
-            }
+        [Option(
+            "log-a-key",
+            Required = false,
+            HelpText = "(required when adding Log Analytics) The shared key for Log Analytics")]
+        public string LogAnalyticsSharedKey { get; set; }
 
-            _deviceId = Environment.GetEnvironmentVariable("DEVICE_ID");
-            if (!string.IsNullOrEmpty(_parameters.DeviceId))
-            {
-                _deviceId = _parameters.DeviceId;
-            }
 
-            // check if EH info is provided
-            if (string.IsNullOrWhiteSpace(_eventHubConnectionString))
-            {
-                Console.WriteLine($"ERROR: _eventHubConnectionString not found.\n\n");
-                Console.WriteLine(CommandLine.Text.HelpText.AutoBuild(result, null, null));
-                Environment.Exit(1);
-            }
-
-            if (string.IsNullOrWhiteSpace(_eventHubName))
-            {
-                Console.WriteLine($"ERROR: _eventHubName not found.\n\n");
-                Console.WriteLine(CommandLine.Text.HelpText.AutoBuild(result, null, null));
-                Environment.Exit(1);
-            }
-
-            double.TryParse(_parameters.Timeout, out _timeoutInterval);
-            _showAsaMessage = _parameters.ShowMsg;
-            _csvFile = _parameters.csvOutputFile;
-            _customLabel = _parameters.TestLabel;
-            
-            _transmitterConfigData = new TransmitterConfigData {
-                autoStart = false,
-                burstLength=_parameters.burstLength,
-                burstWait=_parameters.burstWait,
-                burstNumber=_parameters.burstNumber,
-                targetRate=_parameters.targetRate,
-                payloadLength=_parameters.payloadLength,
-                batchSize=_parameters.batchSize,
-                logMsg=false,
-                logBurst=true,
-                logHist=false,
-                waitBeforeStart=_parameters.waitBeforeStart,
-                rateCalcPeriod=5000
-            };
-        }
     }
+
+   
 }

--- a/source/IotEdgePerf.ConsoleApp/Program.cs
+++ b/source/IotEdgePerf.ConsoleApp/Program.cs
@@ -13,6 +13,9 @@ using IotEdgePerf.Service;
 using IotEdgePerf.Shared;
 using IotEdgePerf.Analysis;
 
+using CommandLine;
+using Microsoft.Azure.Devices;
+
 namespace IotEdgePerf.ConsoleApp
 {
     partial class Program
@@ -35,16 +38,16 @@ namespace IotEdgePerf.ConsoleApp
         private static TransmitterConfigData _transmitterConfigData;
         private static BurstAnalyzer _analyzer;
 
+        private static RegistryManager _registryManager;
+        private static ServiceClient _serviceClient;
+
         private static Guid _sessionId;
         private static string _csvFile;
         private static string _customLabel;
 
         public static async Task Main(string[] args)
         {
-            _sessionId = Guid.NewGuid();
-
-            GetConfig(args);
-
+            
             // Set up a way for the user to gracefully shutdown
             using var cts = new CancellationTokenSource();
             Console.CancelKeyPress += (sender, eventArgs) =>
@@ -54,8 +57,182 @@ namespace IotEdgePerf.ConsoleApp
                 Console.WriteLine("\n\nExiting...");
             };
 
+            // init command line options and verbs
+            
+            await CommandLine.Parser.Default.ParseArguments<DeployOptions, RunOptions>(args)
+                    .MapResult(
+                        (DeployOptions opts) => DeployModules(opts, cts),
+                        (RunOptions opts) => RunPerformanceTest(opts, cts),
+                        errs => Task.FromResult(0)
+                        );
+            
+            
+        }
+
+        private static void SetTimeout(double interval, CancellationTokenSource cts)
+        {
+            // Create a timer with a two second interval.
+            _timeout = new System.Timers.Timer(interval);
+            // Hook up the Elapsed event for the timer. 
+            _timeout.Elapsed += (sender, args) => OnTimeout(cts);
+            _timeout.AutoReset = false;
+            _timeout.Enabled = true;
+        }
+
+
+        private static async Task DeployModules(DeployOptions opts, CancellationTokenSource ct)
+        {
+            _iotHubConnectionString = Environment.GetEnvironmentVariable("IOT_CONN_STRING");
+            bool addingLogAnalytics = false;
+            if (!string.IsNullOrEmpty(opts.IotHubConnectionString))
+            {
+                _iotHubConnectionString = opts.IotHubConnectionString;
+            }
+
+            _deviceId = Environment.GetEnvironmentVariable("DEVICE_ID");
+            if (!string.IsNullOrEmpty(opts.DeviceId))
+            {
+                _deviceId = opts.DeviceId;
+            }
+
+            if (!string.IsNullOrWhiteSpace(opts.LogAnalyticsWorkspaceId))
+            {
+                addingLogAnalytics = true; 
+                //check additionally if the other related values are provided:
+                if(string.IsNullOrWhiteSpace(opts.LogAnalyticsSharedKey) 
+                    || string.IsNullOrWhiteSpace(opts.LogAnalyticsIoTResourceId))
+                    {
+                        Console.WriteLine($"ERROR: You have provided a Log Analytics Workspace ID but missing either IoT Hub resource id or Shared key.\nExiting...\n");
+                        Environment.Exit(1);
+                    }
+                
+            }
+            
+            _registryManager = RegistryManager.CreateFromConnectionString(_iotHubConnectionString);
+
+
+            ConfigurationContent deploymentManifest = EdgeConfigurations.GetBaseConfigurationContent(
+                opts.ImageUri,
+                opts.MaxUpstreamBatchSize,
+                opts.LogAnalyticsWorkspaceId,
+                opts.LogAnalyticsSharedKey,
+                opts.LogAnalyticsIoTResourceId,
+                addingLogAnalytics
+            );
+
+            //in case deployment is for Metrics collector, add these:
+            if (!string.IsNullOrWhiteSpace(opts.LogAnalyticsWorkspaceId))
+            {
+                var edgeAgent = deploymentManifest.ModulesContent["$edgeAgent"]["properties.desired"];
+                Console.WriteLine(edgeAgent);
+            }
+
+            Console.WriteLine("====TODELETE=================");
+            Console.WriteLine(JsonConvert.SerializeObject(deploymentManifest));
+            Console.WriteLine("======TODELETE===============");
+
+            
+            await _registryManager.ApplyConfigurationContentOnDeviceAsync(_deviceId, deploymentManifest);
+            Console.WriteLine("Deploy Modules - Applied configuration (deployment manfiest applied)");
+
+
+            //restart edgeAgent
+            _serviceClient = ServiceClient.CreateFromConnectionString(_iotHubConnectionString);
+
+            var deviceMethod = new CloudToDeviceMethod("RestartModule");
+            deviceMethod.ResponseTimeout = TimeSpan.FromSeconds(30);
+
+            var json = new 
+            {
+                schemaVersion = "1.0",
+                id = "edgeHub"
+            };
+            deviceMethod.SetPayloadJson(JsonConvert.SerializeObject(json));
+
+            try
+            {
+                var response = await _serviceClient.InvokeDeviceMethodAsync(_deviceId, "$edgeAgent", deviceMethod);
+                Console.WriteLine($"Deploy Modules - Restart module: {response.Status}");
+            }
+            catch(System.Exception e)
+            {
+                Console.WriteLine($"Deploy Modules - could not restart edgeAgent: {e.Message}");
+            }
+            
+            Console.WriteLine("\nFinished with deployment.");
+
+        }
+
+        private static async Task RunPerformanceTest(RunOptions opts, CancellationTokenSource ct)
+        {
+            //==== Initialize
+            _eventHubName = Environment.GetEnvironmentVariable("EH_NAME");
+            if (!string.IsNullOrEmpty(opts.EventHubName))
+            {
+                _eventHubName = opts.EventHubName;
+            }
+
+            _eventHubConnectionString = Environment.GetEnvironmentVariable("EH_CONN_STRING");
+            if (!string.IsNullOrEmpty(opts.EventHubConnectionString))
+            {
+                _eventHubConnectionString = opts.EventHubConnectionString;
+            }
+
+            _iotHubConnectionString = Environment.GetEnvironmentVariable("IOT_CONN_STRING");
+            if (!string.IsNullOrEmpty(opts.IotHubConnectionString))
+            {
+                _iotHubConnectionString = opts.IotHubConnectionString;
+            }
+
+            _deviceId = Environment.GetEnvironmentVariable("DEVICE_ID");
+            if (!string.IsNullOrEmpty(opts.DeviceId))
+            {
+                _deviceId = opts.DeviceId;
+            }
+
+            // check if EH info is provided
+            if (string.IsNullOrWhiteSpace(_eventHubConnectionString))
+            {
+                Console.WriteLine($"ERROR: _eventHubConnectionString not found.\n\n");
+                //Console.WriteLine(CommandLine.Text.HelpText..AutoBuild(result, null, null));
+                Environment.Exit(1);
+            }
+
+            if (string.IsNullOrWhiteSpace(_eventHubName))
+            {
+                Console.WriteLine($"ERROR: _eventHubName not found.\n\n");
+                //Console.WriteLine(CommandLine.Text.HelpText.AutoBuild(result, null, null));
+                Environment.Exit(1);
+            }
+
+            double.TryParse(opts.Timeout, out _timeoutInterval);
+            _showAsaMessage = opts.ShowMsg;
+            _csvFile = opts.csvOutputFile;
+            _customLabel = opts.TestLabel;
+            
+            _transmitterConfigData = new TransmitterConfigData {
+                autoStart = false,
+                burstLength=opts.burstLength,
+                burstWait=opts.burstWait,
+                burstNumber=opts.burstNumber,
+                targetRate=opts.targetRate,
+                payloadLength=opts.payloadLength,
+                batchSize=opts.batchSize,
+                logMsg=false,
+                logBurst=true,
+                logHist=false,
+                waitBeforeStart=opts.waitBeforeStart,
+                rateCalcPeriod=5000
+            };
+
+
+            //===== RUN
+            _sessionId = Guid.NewGuid();
+
+            
+
             // start timeout
-            SetTimeout(_timeoutInterval, cts);
+            SetTimeout(_timeoutInterval, ct);
 
             if (
                 !String.IsNullOrEmpty(_iotHubConnectionString)
@@ -88,19 +265,9 @@ namespace IotEdgePerf.ConsoleApp
             ); ;
 
             // listens to EH messages
-            await ReceiveMessagesFromDeviceAsync(cts.Token);
+            await ReceiveMessagesFromDeviceAsync(ct.Token);
 
             Console.WriteLine("\nCloud message reader finished.");
-        }
-
-        private static void SetTimeout(double interval, CancellationTokenSource cts)
-        {
-            // Create a timer with a two second interval.
-            _timeout = new System.Timers.Timer(interval);
-            // Hook up the Elapsed event for the timer. 
-            _timeout.Elapsed += (sender, args) => OnTimeout(cts);
-            _timeout.AutoReset = false;
-            _timeout.Enabled = true;
         }
 
         private static void OnTimeout(CancellationTokenSource cts)

--- a/source/IotEdgePerf.ConsoleApp/Program.cs
+++ b/source/IotEdgePerf.ConsoleApp/Program.cs
@@ -110,7 +110,6 @@ namespace IotEdgePerf.ConsoleApp
             
             _registryManager = RegistryManager.CreateFromConnectionString(_iotHubConnectionString);
 
-
             ConfigurationContent deploymentManifest = EdgeConfigurations.GetBaseConfigurationContent(
                 opts.ImageUri,
                 opts.MaxUpstreamBatchSize,
@@ -120,21 +119,8 @@ namespace IotEdgePerf.ConsoleApp
                 addingLogAnalytics
             );
 
-            //in case deployment is for Metrics collector, add these:
-            if (!string.IsNullOrWhiteSpace(opts.LogAnalyticsWorkspaceId))
-            {
-                var edgeAgent = deploymentManifest.ModulesContent["$edgeAgent"]["properties.desired"];
-                Console.WriteLine(edgeAgent);
-            }
-
-            Console.WriteLine("====TODELETE=================");
-            Console.WriteLine(JsonConvert.SerializeObject(deploymentManifest));
-            Console.WriteLine("======TODELETE===============");
-
-            
             await _registryManager.ApplyConfigurationContentOnDeviceAsync(_deviceId, deploymentManifest);
             Console.WriteLine("Deploy Modules - Applied configuration (deployment manfiest applied)");
-
 
             //restart edgeAgent
             _serviceClient = ServiceClient.CreateFromConnectionString(_iotHubConnectionString);
@@ -228,8 +214,6 @@ namespace IotEdgePerf.ConsoleApp
 
             //===== RUN
             _sessionId = Guid.NewGuid();
-
-            
 
             // start timeout
             SetTimeout(_timeoutInterval, ct);


### PR DESCRIPTION
Moved the .sh deployment file into new commands through the single CLI console app.
Doc updated, however I did not remove the .sh or manifest.json files, if folks still want to use them. Just no longer documented.
